### PR TITLE
Add support for custom headers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ const args = parse(Deno.args, { boolean: ["help", "h"] }) as {
   help?: boolean;
   h?: boolean;
   out?: string;
-  auth?: string;
+  headers?: string;
 };
 
 if (Deno.args.length < 1 || args.help || args.h) {
@@ -32,9 +32,14 @@ if (Deno.args.length < 1 || args.help || args.h) {
 
 const url = args._[0];
 let path = args.out;
-const authorizationString = args.auth;
-const authorizationHeader = authorizationString?.split(":")[0];
-const authorization = authorizationString?.split(":")[1];
+const headerString = args.headers;
+
+const customHeaders = (headerString?.split(",") || [])
+  .map((header) => ({ key: header.split(":")[0], value: header.split(":")[1] }))
+  .reduce((map, pair: { key: string; value: string }) => {
+    map[pair.key.trim()] = pair.value.trim();
+    return map;
+  }, {});
 
 const urlRegexp = /https?:\/\/*/;
 if (!urlRegexp.test(url)) {
@@ -46,8 +51,7 @@ console.log(`Creating the postman collection for ${url}`);
 
 const { postmanCollection } = await createPostmanCollection(
   url,
-  authorizationHeader,
-  authorization,
+  customHeaders,
 );
 
 path = path ||

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,9 @@ if (Deno.args.length < 1 || args.help || args.h) {
 
 const url = args._[0];
 let path = args.out;
-const authorization = args.auth;
+const authorizationString = args.auth;
+const authorizationHeader = authorizationString?.split(":")[0];
+const authorization = authorizationString?.split(":")[1];
 
 const urlRegexp = /https?:\/\/*/;
 if (!urlRegexp.test(url)) {
@@ -42,9 +44,14 @@ if (!urlRegexp.test(url)) {
 
 console.log(`Creating the postman collection for ${url}`);
 
-const {postmanCollection} = await createPostmanCollection(url, authorization);
+const { postmanCollection } = await createPostmanCollection(
+  url,
+  authorizationHeader,
+  authorization,
+);
 
-path = path || "./out/" + postmanCollection.info.name + ".postman_collection.json";
+path = path ||
+  "./out/" + postmanCollection.info.name + ".postman_collection.json";
 path && ensureDirSync("./out/");
 try {
   !path && ensureFileSync(path);

--- a/src/format.ts
+++ b/src/format.ts
@@ -42,8 +42,7 @@ export interface PostmanCollection {
 function queryToItem(
   query: FormattedQuery,
   url: string,
-  authorizationHeader?: string,
-  authorization?: string,
+  customHeaders: object,
 ): PostmanItem {
   const baseUrl = url.split("//")[1];
   const rootUrl = baseUrl.split("/")[0];
@@ -51,15 +50,21 @@ function queryToItem(
   const host = [...rootUrl.split(".")];
   const protocol = url.split("://")[0];
 
+  const standardHeadersList = [
+    { key: "Content-Type", value: "application/json" },
+    { key: "Accept", value: "application/json" },
+  ];
+
+  const customHeadersList = Object.keys(customHeaders).map((key) => ({
+    key: key,
+    value: "",
+  }));
+
   const postmanItem: PostmanItem = {
     name: query.outrospectQuery.name,
     request: {
       method: "POST",
-      header: [
-        ...((authorization && authorizationHeader)
-          ? [{ key: authorizationHeader.trim(), value: authorization.trim() }]
-          : []),
-      ],
+      header: [...customHeadersList, ...standardHeadersList],
       body: {
         mode: "graphql",
         graphql: {

--- a/src/format.ts
+++ b/src/format.ts
@@ -42,6 +42,7 @@ export interface PostmanCollection {
 function queryToItem(
   query: FormattedQuery,
   url: string,
+  authorizationHeader?: string,
   authorization?: string,
 ): PostmanItem {
   const baseUrl = url.split("//")[1];
@@ -55,8 +56,8 @@ function queryToItem(
     request: {
       method: "POST",
       header: [
-        ...(authorization
-          ? [{ key: "Authorization", value: authorization }]
+        ...((authorization && authorizationHeader)
+          ? [{ key: authorizationHeader.trim(), value: authorization.trim() }]
           : []),
       ],
       body: {
@@ -83,17 +84,22 @@ function queryToItem(
 export function queryCollectionToPostmanCollection(
   queryCollection: QueryCollection,
   url: string,
+  authorizationHeader?: string,
   authorization?: string,
 ) {
   const item: PostmanFolder[] = [];
   item.push({ name: "Queries", item: [] });
   queryCollection.queries.forEach((query) => {
-    item[0].item.push(queryToItem(query, url, authorization));
+    item[0].item.push(
+      queryToItem(query, url, authorizationHeader, authorization),
+    );
   });
   // @TODO: separate queries and mutations in folders
   item.push({ name: "Mutations", item: [] });
   queryCollection.mutations.forEach((query) => {
-    item[1].item.push(queryToItem(query, url, authorization));
+    item[1].item.push(
+      queryToItem(query, url, authorizationHeader, authorization),
+    );
   });
 
   const name = url.split("//")[1].split("/")[0] + "-GraphMan";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,21 +7,18 @@ export { outrospect };
 
 export async function createPostmanCollection(
   url: string,
-  authorizationHeader?: string,
-  authorization?: string,
+  headers: object,
 ) {
   const introspection = await fetchIntrospection(
     url,
-    authorizationHeader,
-    authorization,
+    headers,
   );
   const outrospection = outrospect(introspection);
   const queryCollection = outrospectionToQueries(outrospection);
   const postmanCollection = queryCollectionToPostmanCollection(
     queryCollection,
     url,
-    authorizationHeader,
-    authorization,
+    headers,
   );
   return { postmanCollection, outrospection, introspection };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,20 @@ export { outrospect };
 
 export async function createPostmanCollection(
   url: string,
+  authorizationHeader?: string,
   authorization?: string,
 ) {
-  const introspection = await fetchIntrospection(url, authorization);
+  const introspection = await fetchIntrospection(
+    url,
+    authorizationHeader,
+    authorization,
+  );
   const outrospection = outrospect(introspection);
   const queryCollection = outrospectionToQueries(outrospection);
   const postmanCollection = queryCollectionToPostmanCollection(
     queryCollection,
     url,
+    authorizationHeader,
     authorization,
   );
   return { postmanCollection, outrospection, introspection };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,25 +4,28 @@ import {
   IntrospectionQuery,
 } from "https://esm.sh/v90/graphql@16.5.0";
 
+import "https://deno.land/x/lodash@4.17.19/dist/lodash.js";
+
+// now `_` is imported in the global variable, which in deno is `self`
+const _ = (self as any)._;
+
 async function query(
   url: string,
   query: string,
-  authorizationHeader?: string,
-  authorization?: string,
+  customHeaders: object,
 ) {
-  const headers = {
+  const standardHeaders = {
     "Content-Type": "application/json",
     "Accept": "application/json",
   };
 
-  if (authorizationHeader && authorization) {
-    headers[authorizationHeader.trim()] = authorization.trim();
-  }
-
   try {
     const res = await fetch(url, {
       method: "POST",
-      headers: headers,
+      headers: {
+        ...standardHeaders,
+        ...customHeaders,
+      },
       body: JSON.stringify({
         query,
       }),
@@ -44,15 +47,13 @@ export function saveJsonFormatted(json: any, path: string) {
 
 export async function fetchIntrospection(
   url: string,
-  authorizationHeader?: string,
-  authorization?: string,
+  customHeaders: object,
 ) {
   const introspectionQueryString = getIntrospectionQuery();
   const introspection = await query(
     url,
     introspectionQueryString,
-    authorizationHeader,
-    authorization,
+    customHeaders,
   );
   if (!introspection.data) {
     throw new Error(

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,15 +4,25 @@ import {
   IntrospectionQuery,
 } from "https://esm.sh/v90/graphql@16.5.0";
 
-async function query(url: string, query: string, authorization?: string) {
+async function query(
+  url: string,
+  query: string,
+  authorizationHeader?: string,
+  authorization?: string,
+) {
+  const headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+  };
+
+  if (authorizationHeader && authorization) {
+    headers[authorizationHeader.trim()] = authorization.trim();
+  }
+
   try {
     const res = await fetch(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "X-Shopify-Storefront-Access-Token": authorization || "",
-      },
+      headers: headers,
       body: JSON.stringify({
         query,
       }),
@@ -32,11 +42,16 @@ export function saveJsonFormatted(json: any, path: string) {
   });
 }
 
-export async function fetchIntrospection(url: string, authorization?: string) {
+export async function fetchIntrospection(
+  url: string,
+  authorizationHeader?: string,
+  authorization?: string,
+) {
   const introspectionQueryString = getIntrospectionQuery();
   const introspection = await query(
     url,
     introspectionQueryString,
+    authorizationHeader,
     authorization,
   );
   if (!introspection.data) {


### PR DESCRIPTION
- This is prevent us from hard coding the header in the code.

- Now the headers can be sent as `--headers 'X-Auth-Token: i-am-a-token, X-Another-Dummy-Header: dummy-value'`
- Since we are allowing custom headers, the switch is changed to `--headers` instead of `--auth`

## Description

Fixes # (issue)

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have ran `deno task ci` to ensure that my code is formatted and linted.
- [ ] I have linked the related issue _(if there is no related issue please
      create one)_
- [ ] ~~I have added tests if applicable~~ (_needs tests to be ready_)
